### PR TITLE
refactor: correctly change mobile drawer state on route change

### DIFF
--- a/components/layout/dashboard/dashboard-sidebar.tsx
+++ b/components/layout/dashboard/dashboard-sidebar.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { Fragment, useRef } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { useDashboardStore } from "~/lib/layout/dashboard/dashboard-store";
 import { sidebarMenu } from "~/lib/layout/dashboard/sidebar-data";
 
@@ -12,6 +12,20 @@ export function DashboardSidebar() {
   const router = useRouter();
   const { sidebarOpen, setSidebarOpen } = useDashboardStore(state => state);
   const initialFocusItem = useRef(null);
+
+  useEffect(() => {
+    const handleBeforeHistoryChange = () => {
+      if (sidebarOpen) {
+        setSidebarOpen(false);
+      }
+    };
+
+    router.events.on("beforeHistoryChange", handleBeforeHistoryChange);
+
+    return () => {
+      router.events.off("beforeHistoryChange", handleBeforeHistoryChange);
+    };
+  }, [router.events, sidebarOpen, setSidebarOpen]);
 
   return (
     <>


### PR DESCRIPTION
## Description

When changing routes, the mobile drawer closes, however the drawer state doesn't properly change, causing the drawer state on the Zustand store and the actual dialog state to disagree. This changes the mobile drawer implementation so the state properly gets changed on route change.
